### PR TITLE
Add TrackingDisabler

### DIFF
--- a/src/components/TrackingDisabler.tsx
+++ b/src/components/TrackingDisabler.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from "react";
+
+import { EmbedTrackingProps } from "../types";
+
+interface Props extends EmbedTrackingProps {
+  disable?: boolean;
+}
+
+const TrackingDisabler = ({ id, disable = false }: Props) => {
+  const [scriptKey, setScriptKey] = useState(0);
+  useEffect(() => {
+    setScriptKey((num) => num + 1);
+  }, [disable, id]);
+
+  return (
+    <script
+      key={scriptKey}
+      dangerouslySetInnerHTML={{
+        __html: `window["ga-disable-${id}"] = ${disable.toString()};`,
+      }}
+    />
+  );
+};
+
+export default TrackingDisabler;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { default as TrackingHeadScript } from "./components/TrackingHeadScript";
 export { default as TrackingBodyScript } from "./components/TrackingBodyScript";
+export { default as TrackingDisabler } from "./components/TrackingDisabler";
 export { default as trackEvent } from "./utils/trackEvent";
 export {
   EmbedTrackingProps,


### PR DESCRIPTION
A potential solution. It's injecting a script tag, hopefully avoiding race conditions between the variable being set and GTAG library loading.

Ref: https://developers.google.com/analytics/devguides/collection/gtagjs/user-opt-out

The only thing I do not like is needing to know the Analytics ID when using the component.

Closes #9 
